### PR TITLE
add setWon call to fix You Won msg on lost game

### DIFF
--- a/src/components/Play/Play.js
+++ b/src/components/Play/Play.js
@@ -76,6 +76,7 @@ const Play = ({
       })
       setAlerted(true)
       setGameOver(true)
+      setWon(false)
     }
   }, [guesses, correctLetters])
 


### PR DESCRIPTION
Hey Joe, I'm a GA grad who ran across your Hangman repo via LinkedIn. Awesome app to code in a couple days! When I played, I noticed I would get a "You Won" message in the guessed letters div when I ran out of guesses, so I thought I'd practice my GitHub pull request workflow and send you this suggested fix which at least works for me on localhost. Cheers!